### PR TITLE
Add ability to unmount nfs shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ Install nfs server components
 ---------------
 
 Install nfs client components
+
+``nfs.mount``
+---------------
+
+Mount nfs shares via. pillar using the following parameters:
+* mountpoint
+* location
+* opts: default => "vers=3"
+* persist: default => True
+* mkmnt: default => True
+
+``nfs.unmount``
+---------------
+
+Unmount nfs shares via. pillar using the following parameters:
+* mountpoint
+* location
+* persist: default => False

--- a/nfs/files/exports
+++ b/nfs/files/exports
@@ -1,3 +1,8 @@
+########################################################################
+# File managed by Salt at <{{ source }}>.
+# Your changes will be overwritten.
+########################################################################
+#
 {% for dir, opts in salt['pillar.get']('nfs:server:exports').items() -%}
 {{ dir }} {{ opts }}
 {% endfor -%}

--- a/nfs/unmount.sls
+++ b/nfs/unmount.sls
@@ -1,0 +1,23 @@
+{% from "nfs/map.jinja" import nfs with context %}
+
+include:
+  - nfs.client
+
+# Parameter device for mount.unmounted: New in version 2015.5.0.
+# Errors: if not used with newer minions
+# Warnings: if used with older minions
+# Using the following values followed by the conditional avoids both issues
+{% set version_year = grains.saltversioninfo[0] %}
+{% set version_month = grains.saltversioninfo[1] %}
+{% set min_year = 2015 %}
+{% set min_month = 5 %}
+{% set use_device = (version_year > min_year or (version_year == min_year and version_month >= min_month)) %}
+
+{% for m in salt['pillar.get']('nfs:unmount').iteritems() %}
+{{ m[1].mountpoint }}:
+  mount.unmounted:
+  {% if use_device %}
+    - device: {{ m[1].location }}
+  {% endif %}
+    - persist: {{ m[1].persist|default('False') }}
+{% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -9,4 +9,9 @@ nfs:
       opts: "vers=3,rsize=65535,wsize=65535"
       persist: True
       mkmnt: True
+  unmount:
+    someothername:
+      mountpoint: "/some/other/path"
+      location: "hostname:/other/path"
+      persist: False
 


### PR DESCRIPTION
- Complements `mount.mounted` by using `mount.unmounted`
- Since `device` parameter causes warnings on older minion versions,
  included a test to determine whether the parameter should be used
- Other changes include:
  - Update `pillar.example` to show how unmount is to be used
  - Update `README` to include `nfs.mount` and `nfs.unmount`
  - Add standard manual edit warning to managed `exports` file
