### PR TITLE
allow export template to be configurable

### DIFF
--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -14,7 +14,7 @@
 } %}
 
 # is support for <0.17 still required?
-{% if grains.get('saltversioninfo:0', '0') == 0 and grains.get('saltversioninfo:1', '16') < 17  %}
+{% if grains.get('saltversioninfo:0', '') == 0 and grains.get('saltversioninfo:1', '') < 17  %}
 {% set nfs = map.get(grains.os) %}
 {% else %}
 {% set nfs = salt['grains.filter_by'](map, merge=salt['pillar.get']('nfs:lookup')) %}

--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -9,13 +9,8 @@
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
         'service_name': 'nfs-kernel-server',
-	'export_template': 'salt://nfs/files/exports'
+        'export_template': 'salt://nfs/files/exports'
     }
 } %}
 
-# is support for <0.17 still required?
-{% if grains.get('saltversioninfo:0', '') == 0 and grains.get('saltversioninfo:1', '') < 17  %}
-{% set nfs = map.get(grains.os) %}
-{% else %}
 {% set nfs = salt['grains.filter_by'](map, merge=salt['pillar.get']('nfs:lookup')) %}
-{% endif %}

--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -8,7 +8,7 @@
     'Debian': {
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
-        'service_name': 'nfs-kernel-server'
+        'service_name': 'nfs-kernel-server',
 	'export_template': 'salt://nfs/files/exports'
     }
 } %}

--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -2,12 +2,14 @@
     'Ubuntu': {
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
-        'service_name': 'nfs-kernel-server'
+        'service_name': 'nfs-kernel-server',
+	'export_template': 'salt://nfs/files/exports'
     },
     'Debian': {
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
         'service_name': 'nfs-kernel-server'
+	'export_template': 'salt://nfs/files/exports'
     }
 } %}
 

--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -13,8 +13,9 @@
     }
 } %}
 
-{% if grains.get('saltversion', '').startswith('0.17') %}
-{% set nfs = salt['grains.filter_by'](map, merge=salt['pillar.get']('nfs:lookup'), base='default') %}
-{% else %}
+# is support for <0.17 still required?
+{% if grains.get('saltversioninfo:0', '0') == 0 and grains.get('saltversioninfo:1', '16') < 17  %}
 {% set nfs = map.get(grains.os) %}
+{% else %}
+{% set nfs = salt['grains.filter_by'](map, merge=salt['pillar.get']('nfs:lookup')) %}
 {% endif %}

--- a/nfs/server.sls
+++ b/nfs/server.sls
@@ -6,7 +6,7 @@ nfs-server-deps:
 
 /etc/exports:
   file.managed:
-    - source: salt://nfs/files/exports
+    - source: {{ nfs.export_template }}
     - template: jinja
     - watch_in:
       - service: nfs-service

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,6 @@
 nfs:
   lookup:
-    export_template: salt:/nfs/files/customexport
+    export_template: salt://nfs/files/customexport
   server:
     exports: 
       /srv/homes: "hostname1(rw,sync,no_subtree_check) hostname2(ro,sync,no_subtree_check)"

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,6 @@
 nfs:
+  lookup:
+    export_template: salt:/nfs/files/customexport
   server:
     exports: 
       /srv/homes: "hostname1(rw,sync,no_subtree_check) hostname2(ro,sync,no_subtree_check)"


### PR DESCRIPTION
regarding https://github.com/saltstack-formulas/nfs-formula/issues/7

also fixes existing bug that locked pillar lookups for map.jinja to only 0.17
