### PR TITLE
Added support for RedHat

### DIFF
--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -8,11 +8,12 @@
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
         'service_name': 'nfs-kernel-server'
+    },
+    'RedHat': {
+        'pkgs_server': ['nfs-utils'],
+        'pkgs_client': ['nfs-utils'],
+        'service_name': 'nfs-server'
     }
 } %}
 
-{% if grains.get('saltversion', '').startswith('0.17') %}
 {% set nfs = salt['grains.filter_by'](map, merge=salt['pillar.get']('nfs:lookup'), base='default') %}
-{% else %}
-{% set nfs = map.get(grains.os) %}
-{% endif %}


### PR DESCRIPTION
Included support for RedHat/CentOS. Simple addition of packaged and services seems to be enough.

Have tested on CentOS 7.
