### PR TITLE
Revert "RedHat and FreeBSD support"

### DIFF
--- a/nfs/client.sls
+++ b/nfs/client.sls
@@ -1,14 +1,5 @@
 {% from "nfs/map.jinja" import nfs with context %}
 
-{% if nfs.pkgs_client %}
 nfs-client-deps:
     pkg.installed:
         - pkgs: {{ nfs.pkgs_client|json }}
-{% endif %}
-
-{% if nfs.service_client %}
-nfs-service:
-  service.running:
-    - name: {{ nfs.service_client }}
-    - enable: True
-{% endif %}

--- a/nfs/files/exports
+++ b/nfs/files/exports
@@ -3,6 +3,6 @@
 # Your changes will be overwritten.
 ########################################################################
 #
-{% for dir, opts in salt['pillar.get']('nfs:server:exports', {}).items() -%}
+{% for dir, opts in salt['pillar.get']('nfs:server:exports').items() -%}
 {{ dir }} {{ opts }}
 {% endfor -%}

--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -2,28 +2,17 @@
     'Ubuntu': {
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
-        'service_server': 'nfs-kernel-server',
-        'service_client': False,
+        'service_name': 'nfs-kernel-server'
     },
     'Debian': {
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
-        'service_server': 'nfs-kernel-server',
-        'service_client': False,
-    },
-    'FreeBSD': {
-        'pkgs_client': False,
-        'pkgs_server': False,
-        'service_server': 'nfsd',
-        'service_client': False,
-    },
-    'RedHat': {
-        'pkgs_server': ['nfs-utils'],
-        'pkgs_client': ['nfs-utils'],
-        'service_server_dependency': 'rpcbind',
-        'service_server': 'nfs',
-        'service_client': 'rpcbind',
-    },
+        'service_name': 'nfs-kernel-server'
+    }
 } %}
 
+{% if grains.get('saltversion', '').startswith('0.17') %}
 {% set nfs = salt['grains.filter_by'](map, merge=salt['pillar.get']('nfs:lookup'), base='default') %}
+{% else %}
+{% set nfs = map.get(grains.os) %}
+{% endif %}

--- a/nfs/server.sls
+++ b/nfs/server.sls
@@ -1,12 +1,8 @@
 {% from "nfs/map.jinja" import nfs with context %}
 
-{#  FreeBSD has everything needed for NFS w/o any
-    additional pkgs, so pkgs_server == False #}
-{% if nfs.pkgs_server %}
 nfs-server-deps:
     pkg.installed:
         - pkgs: {{ nfs.pkgs_server|json }}
-{% endif %}
 
 /etc/exports:
   file.managed:
@@ -15,16 +11,7 @@ nfs-server-deps:
     - watch_in:
       - service: nfs-service
 
-{# RedHat-based OSes requires to start rpcbind first
-    and in some versions there is a bug that it does not start as a dependency #}
-{% if nfs.service_server_dependency %}
-nfs-service-dependency:
-  service.running:
-    - name: {{ nfs.service_server_dependency }}
-    - enable: True
-{% endif %}
-
 nfs-service:
   service.running:
-    - name: {{ nfs.service_server }}
+    - name: {{ nfs.service_name }}
     - enable: True


### PR DESCRIPTION
Reverts saltstack-formulas/nfs-formula#12

The PR, as it stands right now, caused the problems discussed in #13 and should address them before we can consider merging it again.
