### PR TITLE
test if nfs.service_server_dependency is defined

### DIFF
--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -9,7 +9,7 @@
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
         'service_server': 'nfs-kernel-server',
-        'service_client': False,
+        'service_client': 'rpcbind',
     },
     'FreeBSD': {
         'pkgs_client': False,

--- a/nfs/server.sls
+++ b/nfs/server.sls
@@ -17,7 +17,7 @@ nfs-server-deps:
 
 {# RedHat-based OSes requires to start rpcbind first
     and in some versions there is a bug that it does not start as a dependency #}
-{% if nfs.service_server_dependency %}
+{% if nfs.service_server_dependency is defined %}
 nfs-service-dependency:
   service.running:
     - name: {{ nfs.service_server_dependency }}


### PR DESCRIPTION
without, the server state doesn't work on non RedHat OS
