### PR TITLE
Add support for Amazon, CentOS, RedHat Linux

### DIFF
--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -1,4 +1,19 @@
 {% set map = {
+    'Amazon': {
+        'pkgs_server': ['nfs-utils'],
+        'pkgs_client': ['nfs-utils'],
+        'service_name': 'nfs'
+    },
+    'CentOS': {
+        'pkgs_server': ['nfs-utils'],
+        'pkgs_client': ['nfs-utils'],
+        'service_name': 'nfs'
+    },
+    'RedHat': {
+        'pkgs_server': ['nfs-utils'],
+        'pkgs_client': ['nfs-utils'],
+        'service_name': 'nfs'
+    },
     'SUSE': {
         'pkgs_server': ['nfs-kernel-server'],
         'pkgs_client': ['nfs-client'],


### PR DESCRIPTION
Line 42 of map.jinja
{% set nfs = map.get(grains.os) %}
does not allow pillar lookups!

This is a a "convention over configuration" solution.