### PR TITLE
Simplified formula, removed legacy conditionals

### DIFF
--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -1,28 +1,17 @@
-{% set map = {
-    'SUSE': {
-        'pkgs_server': ['nfs-kernel-server'],
-        'pkgs_client': ['nfs-client'],
-        'service_name': 'nfsserver'
-    },
-    'Ubuntu': {
-        'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
-        'pkgs_client': ['nfs-common'],
-        'service_name': 'nfs-kernel-server'
-    },
+{% set nfs = salt['grains.filter_by']({
     'Debian': {
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
         'service_name': 'nfs-kernel-server'
     },
-    'Raspbian': {
-        'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
-        'pkgs_client': ['nfs-common'],
-        'service_name': 'nfs-kernel-server'
-    }
-} %}
-
-{% if grains.get('saltversion', '').startswith('0.17') %}
-{% set nfs = salt['grains.filter_by'](map, merge=salt['pillar.get']('nfs:lookup'), base='default') %}
-{% else %}
-{% set nfs = map.get(grains.os) %}
-{% endif %}
+    'RedHat': {
+        'pkgs_server': ['nfs-utils'],
+        'pkgs_client': ['nfs-utils'],
+        'service_name': 'nfs',
+    },
+    'SUSE': {
+        'pkgs_server': ['nfs-kernel-server'],
+        'pkgs_client': ['nfs-client'],
+        'service_name': 'nfsserver'
+    },
+}, merge=salt['pillar.get']('nfs:lookup'), default='Debian') %}

--- a/nfs/mount.sls
+++ b/nfs/mount.sls
@@ -3,7 +3,7 @@
 include:
   - nfs.client
 
-{% for m in salt['pillar.get']('nfs:mount').items() %}
+{% for m in salt['pillar.get']('nfs:mount', {}).items() %}
 {{ m[1].mountpoint }}:
   mount.mounted:
     - device: {{ m[1].location }}

--- a/nfs/unmount.sls
+++ b/nfs/unmount.sls
@@ -3,21 +3,9 @@
 include:
   - nfs.client
 
-# Parameter device for mount.unmounted: New in version 2015.5.0.
-# Errors: if not used with newer minions
-# Warnings: if used with older minions
-# Using the following values followed by the conditional avoids both issues
-{% set version_year = grains.saltversioninfo[0] %}
-{% set version_month = grains.saltversioninfo[1] %}
-{% set min_year = 2015 %}
-{% set min_month = 5 %}
-{% set use_device = (version_year > min_year or (version_year == min_year and version_month >= min_month)) %}
-
-{% for m in salt['pillar.get']('nfs:unmount').iteritems() %}
+{% for m in salt['pillar.get']('nfs:unmount', {}).iteritems() %}
 {{ m[1].mountpoint }}:
   mount.unmounted:
-  {% if use_device %}
     - device: {{ m[1].location }}
-  {% endif %}
     - persist: {{ m[1].persist|default('False') }}
 {% endfor %}


### PR DESCRIPTION
The maps.jinja code was suffering from some logic errors.
The grains.filter_by code was _only_ executed on the 0.17 salt
versions rather than on 0.17 or newer.
Considering that 0.17 is rather old, we can get rid of these cases
and massively simplify the logic.

By defaulting to the Debian settings and using the os_family graint
to filter by, the Ubuntu and Raspbian cases could be removed as well,
further simplifying the map file.

Add rudimentary Red Hat support.

Have the pillar.get calls in mount.sls and unmount.sls return an
empty default dict to make the SLS rendering not fail in case
no pillar data is provided.

Remove support for pre 2015 saltversion unmount syntax.