### PR TITLE
Adding fedora in map.jinja

### DIFF
--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -13,7 +13,7 @@
         'pkgs_server': ['nfs-utils'],
         'pkgs_client': ['nfs-utils'],
         'service_name': 'nfs'
-    }
+    },
     'RedHat': {
         'pkgs_server': ['nfs-utils'],
         'pkgs_client': ['nfs-utils'],

--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -9,6 +9,11 @@
         'pkgs_client': ['nfs-utils'],
         'service_name': 'nfs'
     },
+    'Fedora': {
+        'pkgs_server': ['nfs-utils'],
+        'pkgs_client': ['nfs-utils'],
+        'service_name': 'nfs'
+    }
     'RedHat': {
         'pkgs_server': ['nfs-utils'],
         'pkgs_client': ['nfs-utils'],


### PR DESCRIPTION
When I tried to use nfs.mount in Fedora, I had an error. It seems package list is missing in map.jinga. I just have copied and pasted RedHat conf