### PR TITLE
Fix Debian's family service name

### DIFF
--- a/nfs/osfamilymap.yaml
+++ b/nfs/osfamilymap.yaml
@@ -2,7 +2,7 @@
 Debian:
   pkgs_server: ['nfs-common', 'nfs-kernel-server']
   pkgs_client: ['nfs-utils']
-  service_name: 'nfs'
+  service_name: 'nfs-server'
 
 Arch:
   pkgs_server: ['nfs-utils']


### PR DESCRIPTION
fixes error introduced in #26 (reported in [this comment](https://github.com/saltstack-formulas/nfs-formula/pull/26#issuecomment-376236563))