### PR TITLE
Client package fix in debian based OS

### DIFF
--- a/nfs/osfamilymap.yaml
+++ b/nfs/osfamilymap.yaml
@@ -1,7 +1,7 @@
 ---
 Debian:
   pkgs_server: ['nfs-common', 'nfs-kernel-server']
-  pkgs_client: ['nfs-utils']
+  pkgs_client: ['nfs-common']
   service_name: 'nfs-server'
 
 Arch:


### PR DESCRIPTION
The package nfs-utils does not exists in Debian 9.4. All clients programs are in nfs-common.